### PR TITLE
Add Color and Change UI Layout

### DIFF
--- a/cdir_cli/user_interface/main_view.py
+++ b/cdir_cli/user_interface/main_view.py
@@ -43,14 +43,13 @@ class MainView:
 
         self.screen.clear()
 
+        screen_width = self.screen.getmaxyx()[1]
         if query.query_text:
-            search_header = "Search: "
-            self.screen.addstr(0, 0,
-                               search_header[:self.__get_folder_column_width()-1],
+            search_header = "Search: "[:screen_width-1]
+            self.screen.addstr(0, 0, search_header,
                                curses.color_pair(self.SEARCH_HEADER_COLOR))
-            search_header_width = len(search_header[:self.__get_folder_column_width()-1])
-            self.screen.addstr(0, search_header_width,
-                               query.query_text[:self.__get_folder_column_width()-1-search_header_width])
+            self.screen.addstr(0, len(search_header),
+                               query.query_text[:screen_width-1-len(search_header)])
         else:
             self.screen.addstr(0, 0,
                                "Current Path: " + folder_navigator[:self.__get_folder_column_width()-1],

--- a/cdir_cli/user_interface/main_view.py
+++ b/cdir_cli/user_interface/main_view.py
@@ -34,12 +34,12 @@ class MainView:
 
     def print_screen(self, folder_navigator: FolderNavigator, query: Query, cursor: Cursor, scroll_position: ScrollPosition):
 
-        if (self.screen.getmaxyx()[0] > 2):
-            self.__draw_header_row(folder_navigator.current_path, query, cursor)
+        if (self.screen.getmaxyx()[0] > self.N_HEADER_ROWS + 1):
+            self.__draw_header_rows(folder_navigator.current_path, query, cursor)
             self.__draw_folders(query.filter_folders(folder_navigator.sub_folders), cursor)
             self.__draw_files(folder_navigator.sub_files, scroll_position)
 
-    def __draw_header_row(self, folder_navigator, query, cursor):
+    def __draw_header_rows(self, folder_navigator, query, cursor):
 
         self.screen.clear()
 
@@ -78,7 +78,7 @@ class MainView:
 
     def __draw_folders(self, folders, cursor):
 
-        pad_max_y_size = self.screen.getmaxyx()[0] - 2
+        pad_max_y_size = self.screen.getmaxyx()[0] - self.N_HEADER_ROWS
         self.file_pad.resize(max(len(folders), pad_max_y_size),
                                self.__get_folder_column_width())
         self.file_pad.clear()
@@ -97,7 +97,7 @@ class MainView:
 
         screen_max_y_coord = self.screen.getmaxyx()[0] - 1
         folder_pad_max_x_coord = self.__get_folder_column_width() - 1
-        self.file_pad.refresh(max(0, (cursor.row_index + 2)  - screen_max_y_coord) ,0,
+        self.file_pad.refresh(max(0, (cursor.row_index + self.N_HEADER_ROWS)  - screen_max_y_coord) ,0,
                         self.N_HEADER_ROWS,0, screen_max_y_coord, folder_pad_max_x_coord -1)
 
     def __draw_files(self, files, file_scroll_position):
@@ -129,4 +129,4 @@ class MainView:
         return self.screen.getmaxyx()[1] - self.__get_folder_column_width()
 
     def __get_file_column_heigth(self):
-        return self.screen.getmaxyx()[0] - 2
+        return self.screen.getmaxyx()[0] - self.N_HEADER_ROWS


### PR DESCRIPTION
I made a few modifications to the UI layout so that each column has its own label, the current directory/search query has its own row, and added color.
Example current directory:
![image](https://user-images.githubusercontent.com/19842971/213523412-aa084aba-7d69-4186-94ec-9d8289f3209e.png)
Example search query:
![image](https://user-images.githubusercontent.com/19842971/213523462-3540a9ac-3ed9-4705-aa25-1ae67f4c7977.png)

I have tested it on Windows, but have not had the chance to play with it on Linux.  The reason for adding the directory column label is that I find it easier to know where the cursor is.  I understand that the UI had feedback indicating the location, but as a new user, consistent indicators is much appreciated.  As for the color...it is just more fun!...and arguably easier to mentally parse quickly.